### PR TITLE
set use_reloader=False

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,4 +132,8 @@ def index():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # set debug=True for easy development and experimentation
+    # set use_reloader=False. when this is set to True it initializes the flask app twice. usually
+    # this isn't a problem, but since we deploy out contract during initialization it ends up getting
+    # deployed twice. when use_reloader is set to False it deploys only once but reloading is disabled
+    app.run(debug=True, use_reloader=False)

--- a/main.py
+++ b/main.py
@@ -134,6 +134,6 @@ def index():
 if __name__ == '__main__':
     # set debug=True for easy development and experimentation
     # set use_reloader=False. when this is set to True it initializes the flask app twice. usually
-    # this isn't a problem, but since we deploy out contract during initialization it ends up getting
+    # this isn't a problem, but since we deploy our contract during initialization it ends up getting
     # deployed twice. when use_reloader is set to False it deploys only once but reloading is disabled
     app.run(debug=True, use_reloader=False)


### PR DESCRIPTION
Set `use_reloader=False`. When this is set to `True` it initializes the flask app twice. Usually this isn't a problem, but since we deploy our contract during initialization it ends up getting deployed twice (and the first deployed contract isn't even used). When `use_reloader` is set to `False` it deploys only once but hot reloading is disabled.